### PR TITLE
Import and recover repeatable jobs

### DIFF
--- a/src/Recruiter/Repeatable.php
+++ b/src/Recruiter/Repeatable.php
@@ -6,7 +6,7 @@ interface Repeatable extends Workable
 {
     /**
      * Assign an unique name to the scheduler in order to handle idempotency,
-     * only one scheduler with the same urn can be exists
+     * only one scheduler with the same urn can exists
      *
      * @return string
      */

--- a/src/Recruiter/RepeatableInJob.php
+++ b/src/Recruiter/RepeatableInJob.php
@@ -2,12 +2,12 @@
 namespace Recruiter;
 
 use Exception;
-use Recruiter\Workable\RecoverWorkableFromException;
+use Recruiter\Workable\RecoverRepeatableFromException;
 
-class WorkableInJob
+class RepeatableInJob
 {
-    // TODO: resolve the duplication with RepeatableInJob
-    public static function import($document): Workable
+    // TODO: resolve duplication with WorkableInJob
+    public static function import($document): Repeatable
     {
         $dataAboutWorkableObject = [
             'parameters' => null,
@@ -28,12 +28,12 @@ class WorkableInJob
             if (!method_exists($dataAboutWorkableObject['class'], 'import')) {
                 throw new Exception('Unable to import Workable without method import');
             }
-            $workable = $dataAboutWorkableObject['class']::import($dataAboutWorkableObject['parameters']);
-            assert($workable instanceof Workable);
-            return $workable;
+            $repeatable =  $dataAboutWorkableObject['class']::import($dataAboutWorkableObject['parameters']);
+            assert($repeatable instanceof Repeatable);
+            return $repeatable;
 
         } catch (Exception $e) {
-            return new RecoverWorkableFromException($dataAboutWorkableObject['parameters'], $dataAboutWorkableObject['class'], $e);
+            return new RecoverRepeatableFromException($dataAboutWorkableObject['parameters'], $dataAboutWorkableObject['class'], $e);
         }
     }
 

--- a/src/Recruiter/RepeatableInJob.php
+++ b/src/Recruiter/RepeatableInJob.php
@@ -2,6 +2,7 @@
 namespace Recruiter;
 
 use Exception;
+use InvalidArgumentException;
 use Recruiter\Workable\RecoverRepeatableFromException;
 
 class RepeatableInJob
@@ -16,19 +17,20 @@ class RepeatableInJob
 
         try {
             if (!array_key_exists('workable', $document)) {
-                throw new Exception('Unable to import Job without data about Workable object');
+                throw new InvalidArgumentException('Unable to import Job without data about Workable object');
             }
             $dataAboutWorkableObject = $document['workable'];
             if (!array_key_exists('class', $dataAboutWorkableObject)) {
-                throw new Exception('Unable to import Job without a class');
+                throw new InvalidArgumentException('Unable to import Job without a class');
             }
             if (!class_exists($dataAboutWorkableObject['class'])) {
-                throw new Exception('Unable to import Job with unknown Workable class');
+                throw new InvalidArgumentException('Unable to import Job with unknown Workable class');
             }
             if (!method_exists($dataAboutWorkableObject['class'], 'import')) {
-                throw new Exception('Unable to import Workable without method import');
+                throw new InvalidArgumentException('Unable to import Workable without method import');
             }
-            $repeatable =  $dataAboutWorkableObject['class']::import($dataAboutWorkableObject['parameters']);
+
+            $repeatable = $dataAboutWorkableObject['class']::import($dataAboutWorkableObject['parameters']);
             assert($repeatable instanceof Repeatable);
             return $repeatable;
 

--- a/src/Recruiter/RepeatableInJob.php
+++ b/src/Recruiter/RepeatableInJob.php
@@ -55,12 +55,12 @@ class RepeatableInJob
         return ['workable' => ['method' => 'execute']];
     }
 
-    private static function classNameOf($workable): string
+    private static function classNameOf($repeatable): string
     {
-        $workableClassName = get_class($workable);
-        if (method_exists($workable, 'getClass')) {
-            $workableClassName = $workable->getClass();
+        $repeatableClassName = get_class($repeatable);
+        if (method_exists($repeatable, 'getClass')) {
+            $repeatableClassName = $repeatable->getClass();
         }
-        return $workableClassName;
+        return $repeatableClassName;
     }
 }

--- a/src/Recruiter/RepeatableInJob.php
+++ b/src/Recruiter/RepeatableInJob.php
@@ -39,7 +39,7 @@ class RepeatableInJob
         }
     }
 
-    public static function export($workable, $methodToCall)
+    public static function export($workable, $methodToCall): array
     {
         return [
             'workable' => [
@@ -50,12 +50,12 @@ class RepeatableInJob
         ];
     }
 
-    public static function initialize()
+    public static function initialize(): array
     {
         return ['workable' => ['method' => 'execute']];
     }
 
-    private static function classNameOf($workable)
+    private static function classNameOf($workable): string
     {
         $workableClassName = get_class($workable);
         if (method_exists($workable, 'getClass')) {

--- a/src/Recruiter/Scheduler.php
+++ b/src/Recruiter/Scheduler.php
@@ -46,7 +46,7 @@ class Scheduler
     {
         return new self(
             $document,
-            WorkableInJob::import($document['job']),
+            RepeatableInJob::import($document['job']),
             SchedulePolicyInJob::import($document),
             RetryPolicyInJob::import($document['job']),
             $repository

--- a/src/Recruiter/Workable/RecoverRepeatableFromException.php
+++ b/src/Recruiter/Workable/RecoverRepeatableFromException.php
@@ -2,10 +2,10 @@
 namespace Recruiter\Workable;
 
 use Exception;
-use Recruiter\Workable;
+use Recruiter\Repeatable;
 use Recruiter\WorkableBehaviour;
 
-class RecoverFromException implements Workable
+class RecoverRepeatableFromException implements Repeatable
 {
     use WorkableBehaviour;
 
@@ -21,7 +21,7 @@ class RecoverFromException implements Workable
 
     public function execute()
     {
-        throw new Exception(
+        throw new \Exception(
             'This job failed while instantiating a workable of class: ' . $this->recoverForClass . PHP_EOL .
             'Original exception: ' . get_class($this->recoverForException) . PHP_EOL .
             $this->recoverForException->getMessage() . PHP_EOL .
@@ -32,5 +32,19 @@ class RecoverFromException implements Workable
     public function getClass()
     {
         return $this->recoverForClass;
+    }
+
+    public function urn(): string
+    {
+        $recoverForInstance = new $this->recoverForClass($this->parameters);
+        assert($recoverForInstance instanceof Repeatable);
+        return $recoverForInstance->urn();
+    }
+
+    public function unique(): bool
+    {
+        $recoverForInstance = new $this->recoverForClass($this->parameters);
+        assert($recoverForInstance instanceof Repeatable);
+        return $recoverForInstance->unique();
     }
 }

--- a/src/Recruiter/Workable/RecoverWorkableFromException.php
+++ b/src/Recruiter/Workable/RecoverWorkableFromException.php
@@ -1,0 +1,36 @@
+<?php
+namespace Recruiter\Workable;
+
+use Exception;
+use Recruiter\Workable;
+use Recruiter\WorkableBehaviour;
+
+class RecoverWorkableFromException implements Workable
+{
+    use WorkableBehaviour;
+
+    protected $recoverForClass;
+    protected $recoverForException;
+
+    public function __construct($parameters, $recoverForClass, $recoverForException)
+    {
+        $this->parameters = $parameters;
+        $this->recoverForClass = $recoverForClass;
+        $this->recoverForException = $recoverForException;
+    }
+
+    public function execute()
+    {
+        throw new Exception(
+            'This job failed while instantiating a workable of class: ' . $this->recoverForClass . PHP_EOL .
+            'Original exception: ' . get_class($this->recoverForException) . PHP_EOL .
+            $this->recoverForException->getMessage() . PHP_EOL .
+            $this->recoverForException->getTraceAsString() . PHP_EOL
+        );
+    }
+
+    public function getClass()
+    {
+        return $this->recoverForClass;
+    }
+}


### PR DESCRIPTION
With PHP 7.4 we have got the following exception

```
2019-12-11T16:21:39.060537+00:00 development-all-vm php: {"message":"Argument 2 passed to Recruiter\\Scheduler::__construct() must implement interface Recruiter\\Repeatable, instance of Recruiter\\Workabl
e\\RecoverFromException given, called in \/var\/www\/mvrs-servizi-muoversiservizi\/releases\/20191211150410\/vendor\/recruiterphp\/recruiter\/src\/Recruiter\/Scheduler.php on line 48","level":3,"level_nam
e":"ERROR","context":{"exception_message":"Argument 2 passed to Recruiter\\Scheduler::__construct() must implement interface Recruiter\\Repeatable, instance of Recruiter\\Workable\\RecoverFromException gi
ven, called in \/var\/www\/mvrs-servizi-muoversiservizi\/releases\/20191211150410\/vendor\/recruiterphp\/recruiter\/src\/Recruiter\/Scheduler.php on line 48","exception_class":"TypeError","file":"\/var\/w
ww\/mvrs-servizi-muoversiservizi\/releases\/20191211150410\/vendor\/recruiterphp\/recruiter\/src\/Recruiter\/Scheduler.php","line":56,"trace":["\/var\/www\/mvrs-servizi-muoversiservizi\/releases\/20191211
150410\/vendor\/recruiterphp\/recruiter\/src\/Recruiter\/Scheduler.php:48","\/var\/www\/mvrs-servizi-muoversiservizi\/releases\/20191211150410\/vendor\/recruiterphp\/recruiter\/src\/Recruiter\/Scheduler\/
Repository.php:72","\/var\/www\/mvrs-servizi-muoversiservizi\/releases\/20191211150410\/vendor\/recruiterphp\/recruiter\/src\/Recruiter\/Scheduler\/Repository.php:26","\/var\/www\/mvrs-servizi-muoversiser
vizi\/releases\/20191211150410\/vendor\/recruiterphp\/recruiter\/src\/Recruiter\/Recruiter.php:120","\/var\/www\/mvrs-servizi-muoversiservizi\/releases\/20191211150410\/vendor\/recruiterphp\/recruiter\/sr
c\/Recruiter\/Infrastructure\/Command\/RecruiterCommand.php:127","\/var\/www\/mvrs-servizi-muoversiservizi\/releases\/20191211150410\/vendor\/recruiterphp\/recruiter\/src\/Recruiter\/Infrastructure\/Comma
nd\/RecruiterCommand.php:84","\/var\/www\/mvrs-servizi-muoversiservizi\/releases\/20191211150410\/vendor\/recruiterphp\/geezer\/src\/Command\/RobustCommandRunner.php:79","\/var\/www\/mvrs-servizi-muoversi
servizi\/releases\/20191211150410\/vendor\/symfony\/console\/Command\/Command.php:255","\/var\/www\/mvrs-servizi-muoversiservizi\/releases\/20191211150410\/vendor\/symfony\/console\/Application.php:917","
\/var\/www\/mvrs-servizi-muoversiservizi\/releases\/20191211150410\/vendor\/symfony\/console\/Application.php:269","\/var\/www\/mvrs-servizi-muoversiservizi\/releases\/20191211150410\/vendor\/symfony\/con
sole\/Application.php:145","\/var\/www\/mvrs-servizi-muoversiservizi\/releases\/20191211150410\/vendor\/recruiterphp\/recruiter\/bin\/recruiter:40"]}}
```

Seems like PHP 7.4 is more strict with types so `WorkableInJob` will not suffice to import `Repeatable` job